### PR TITLE
snap: dbus slot for org.darktable.session

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,13 @@ apps:
       PYTHONPATH: $SNAP/usr/lib/python3/dist-packages
     plugs:
       - network
+
+slots:
+    session-dbus-interface:
+        interface: dbus
+        name: org.darktable.service
+        bus: session
+
 layout:
   /usr/include/clc:
     bind: $SNAP/usr/include/clc


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>